### PR TITLE
explicit keyword argument

### DIFF
--- a/lib/jumanpp_ruby.rb
+++ b/lib/jumanpp_ruby.rb
@@ -6,14 +6,12 @@ module JumanppRuby
   class Juman
     require 'open3'
 
-    def initialize(**options)
-      @option = []
-      @option.tap do |opt|
-        opt << "-B #{options[:beam]}" if options[:beam]
-        opt << '--force-single-path' if options[:force_single_path] == :true
-        opt << '--partial' if options[:partial] == :true
-      end
-      @pipe ||= IO.popen("jumanpp #{@option.join(' ')}".strip, 'r+')
+    def initialize(beam: nil, force_single_path: false, partial: false)
+      argv = ['jumanpp']
+      argv << '--beam' << beam if beam
+      argv << '--force-single-path' if force_single_path
+      argv << '--partial' if partial
+      @pipe = IO.popen(argv, 'r+')
     end
 
     def parse(sentents)


### PR DESCRIPTION
Hello.  I began using this library recently.  I want you to pull something.

First off, I think you should explicitly check the keyword arguments, like this.  Because `options` was not used at all, this code is much simpler, easy to understand, and fast.

Also, you don't have to make string for `IO#popen`.  passing array should just suffice.