### PR TITLE
bug fix in parser

### DIFF
--- a/lib/jumanpp_ruby.rb
+++ b/lib/jumanpp_ruby.rb
@@ -20,12 +20,14 @@ module JumanppRuby
       @pipe.puts(sentents)
       responses = []
       while sentent = @pipe.gets
-        responses << sentent.delete('\\').delete('\"')
+        a = sentent.scan(/(?:\\ |[^\s"]|"[^"]*")+/)
+        a.each {|i| i.sub!(/\A"(.*)"\z/, '\\1') }
+        responses << a
         break if sentent =~ /EOS\n/
       end
       if block_given?
-        responses.each { |word| yield word.split }
-      else responses.map { |word| word.split.first }
+        responses.each { |word| yield word }
+      else responses.map { |word| word.first }
       end
     end
 

--- a/spec/jumanpp_ruby_spec.rb
+++ b/spec/jumanpp_ruby_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'spec_helper'
 
 describe JumanppRuby do
@@ -9,6 +10,15 @@ describe JumanppRuby do
     juman = JumanppRuby::Juman.new(force_single_path: :true)
     parsed_text = juman.parse('モビルスーツの性能の違いが、戦力の決定的差でないということを教えてやる')
     expect(parsed_text).to eq ["モビルスーツ", "の", "性能", "の", "違い", "が", "、", "戦力", "の", "決定", "的", "差", "で", "ない", "と", "いう", "こと", "を", "教えて", "やる", "EOS"]
+  end
+
+  context "proper handing of escape characters" do
+    it '#parse' do
+      juman = JumanppRuby::Juman.new(force_single_path: :true)
+      juman.parse("Ｓｔｒｉｎｇ　ｔｈｅｏｒｙ") do |a|
+        expect(a.size).to eq(12).or(eq(1))
+      end
+    end
   end
 end
 


### PR DESCRIPTION
`.delete('\\').delete('\"')` is definitely wrong.  If you look at http://lotus.kuee.kyoto-u.ac.jp/nl-resource/jumanpp/jumanpp-manual-1.01.pdf, you see an example output includes:

```
家 いえ 家 名詞 6 普通名詞 1 * 0 * 0 "代表表記:家/いえ 漢字読み:訓 カテゴリ:組織・団体; 場 所-施設 ドメイン:家庭・暮らし"
```

Here, these `"`s are purposeful.  You must not delete them blindly.  Rather you have to split the words according to them, then split quotes afterwards.