### PR TITLE
fix typo in read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you passed Japanese text and `&block` as argument, you can handle Morphologic
 require 'jumanpp_ruby'
 
 juman = JumanppRuby::Juman.new(force_single_path: :true)
-jumanpp.parse('ララァ…私を導いてくれ！') do |word|
+juman.parse('ララァ…私を導いてくれ！') do |word|
   p word
 end
 # =>["ララァ", "ララァ", "ララァ", "名詞", "6", "普通名詞", "1", "*", "0", "*", "0", "自動獲得:Wikipedia", "Wikipediaリダイレクト:ララァ・スン"]


### PR DESCRIPTION
read me に誤植があったため修正します


```rb
require 'jumanpp_ruby'

juman = JumanppRuby::Juman.new(force_single_path: :true)
- jumanpp.parse('ララァ…私を導いてくれ！') do |word|
+ juman.parse('ララァ…私を導いてくれ！') do |word|
  p word
end
# =>["ララァ", "ララァ", "ララァ", "名詞", "6", "普通名詞", "1", "*", "0", "*", "0", "自動獲得:Wikipedia", "Wikipediaリダイレクト:ララァ・スン"]
# =>["…", "…", "…", "特殊", "1", "記号", "5", "*", "0", "*", "0", "NIL"]
# =>["私", "わたし", "私", "名詞", "6", "普通名詞", "1", "*", "0", "*", "0", "代表表記:私/わたし", "漢字読み:訓", "カテゴリ:人"]
# =>["を", "を", "を", "助詞", "9", "格助詞", "1", "*", "0", "*", "0", "NIL"]
# =>["導いて", "みちびいて", "導く", "動詞", "2", "*", "0", "子音動詞カ行", "2", "タ系連用テ形", "14", "代表表記:導く/みちびく"]
# =>["くれ", "くれ", "くれる", "接尾辞", "14", "動詞性接尾辞", "7", "母音動詞", "1", "基本連用形", "8", "代表表記:くれる/くれる"]
# =>["！", "！", "！", "特殊", "1", "記号", "5", "*", "0", "*", "0", "NIL"]
# =>["EOS"]
```
